### PR TITLE
[fix] input expander button appearance in the Navigation UI component

### DIFF
--- a/contents/navigation.html
+++ b/contents/navigation.html
@@ -81,7 +81,7 @@
             <option value="value3">List Item</option>
           </select>
         </div>
-        <div class="panel-formElements-item">
+        <div class="panel-formElements-item comboButtons">
           <label for="placeholder01">Label:</label><input type="text" placeholder="Placeholder" id="placeholder01" /><button name="expander" class="expander"></button>
         </div>
       </div>
@@ -226,7 +226,7 @@
             <option value="value3">List Item</option>
           </select>
         </div>
-        <div class="panel-formElements-item">
+        <div class="panel-formElements-item comboButtons">
           <label for="placeholder01">Label:</label><input type="text" placeholder="Placeholder" id="placeholder01" /><button name="expander" class="expander"></button>
         </div>
       </div>
@@ -393,7 +393,7 @@
               &lt;option value=&quot;value3&quot;&gt;List Item&lt;/option&gt;
             &lt;/select&gt;
           &lt;/div&gt;
-          &lt;div class=&quot;panel-formElements-item&quot;&gt;
+          &lt;div class=&quot;panel-formElements-item comboButtons&quot;&gt;
             &lt;label for=&quot;placeholder01&quot;&gt;Label:&lt;/label&gt;&lt;input type=&quot;text&quot; placeholder=&quot;Placeholder&quot; id=&quot;placeholder01&quot; /&gt;&lt;button name=&quot;expander&quot; class=&quot;expander&quot;&gt;&lt;/button&gt;
           &lt;/div&gt;
         &lt;/div&gt;

--- a/src/styles/controls-content.scss
+++ b/src/styles/controls-content.scss
@@ -157,17 +157,6 @@ input[type="checkbox"] {
   box-shadow: 0 0 0 2.5px $color-blue-focusRing;
 }
 
-/* Expander Button */
-
-button.expander {
-  background-image: url("../../images/controls/Arrow-Dropdown.svg");
-  background-position: center;
-  background-repeat: no-repeat;
-  height: 24px;
-  padding: 0;
-  width: 24px;
-}
-
 div.label {
   margin-top: 10px;
 }
@@ -186,6 +175,14 @@ div.label {
   width: 100px;
 }
 
+.comboButtons > button:first-child {
+  margin-left: 0px;
+}
+
+.comboButtons > button:last-child {
+  margin-right: 0px;
+}
+
 .comboButtons > button.hover,
 .comboButtons > button.pressed {
   z-index: 99;
@@ -193,6 +190,17 @@ div.label {
 
 .comboButtons > button:focus {
   z-index: 199;
+}
+
+/* Expander Button */
+
+button.expander {
+  background-image: url("../../images/controls/Arrow-Dropdown.svg");
+  background-position: center;
+  background-repeat: no-repeat;
+  height: 24px;
+  padding: 0;
+  width: 24px;
 }
 
 /* Interactive States */

--- a/src/styles/controls-examples.scss
+++ b/src/styles/controls-examples.scss
@@ -49,3 +49,7 @@ select.icon {
 .mac .comboButtons > button:last-child {
   border-radius: 0 $border-radius-osx $border-radius-osx 0;
 }
+
+.mac .comboButtons > button:first-child:last-child {
+  border-radius: $border-radius-osx;
+}


### PR DESCRIPTION
This PR makes it so that the expander button is merged with the associated `input` element by using the `.comboButtons` class.

### Additional fixes:
- The `button.expander` rule now has higher priority than the `.comboButtons` class
- The first and last button of a `.comboButtons` tag won’t extend outside the `.comboButtons` tag
   (needed for proper alignment)
- If there is only one button in a `.comboButtons` tag, then it will appear correctly on MacOS

---

Yes, I know that this style guide is now deprecated in favour of [Photon](https://github.com/FirefoxUX/photon), but until that has UI components, then this is the only place where to find the navigation panel documentation.